### PR TITLE
Decoder fix

### DIFF
--- a/bioimage_embed/models/bolts/vae.py
+++ b/bioimage_embed/models/bolts/vae.py
@@ -14,7 +14,8 @@ from pl_bolts.models.autoencoders import (
     resnet50_decoder,
     resnet50_encoder,
 )
-
+def count_params(model):
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)
 
 class ResNet50VAEEncoder(BaseEncoder):
     enc_out_dim = 2048
@@ -34,14 +35,13 @@ class ResNet50VAEEncoder(BaseEncoder):
         # self._adaptive_pool = nn.AdaptiveAvgPool2d((embedding_dim, embedding_dim))
 
     def forward(self, x):
-        output = ModelOutput()
         x = self.encoder(x)
         # x = self.fc1(x)
         return ModelOutput(embedding=self.embedding(x), log_covariance=self.log_var(x))
 
 
 class ResNet50VAEDecoder(BaseDecoder):
-    enc_out_dim = 2048
+    enc_out_dim = 512
     def __init__(
         self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs
     ):
@@ -71,13 +71,10 @@ class ResNet18VAEEncoder(BaseEncoder):
         self.encoder = resnet18_encoder(first_conv, maxpool1)
         self.embedding = nn.Linear(self.enc_out_dim, latent_dim)
         self.log_var = nn.Linear(self.enc_out_dim, latent_dim)
-        # self.fc1 = nn.Linear(512, latent_dim)
-        # self._adaptive_pool = nn.AdaptiveAvgPool2d((embedding_dim, embedding_dim))
 
     def forward(self, x):
         x = self.encoder(x)
         # x = self.fc1(x)
-
         return ModelOutput(embedding=self.embedding(x), log_covariance=self.log_var(x))
 
 

--- a/bioimage_embed/models/bolts/vae.py
+++ b/bioimage_embed/models/bolts/vae.py
@@ -40,21 +40,20 @@ class ResNet50VAEEncoder(BaseEncoder):
 
 
 class ResNet50VAEDecoder(BaseDecoder):
+    enc_out_dim = 2048
     def __init__(
         self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs
     ):
         super(ResNet50VAEDecoder, self).__init__()
         latent_dim = model_config.latent_dim
         input_height = model_config.input_dim[-2]
-        self.decoder = resnet50_decoder(latent_dim, input_height, first_conv, maxpool1)
+        self.embedding = nn.Linear(latent_dim, self.enc_out_dim)
+        self.decoder = resnet50_decoder(self.enc_out_dim, input_height, first_conv, maxpool1)
 
     def forward(self, x):
-        output = ModelOutput()
-        # output = ModelOutput()
+        x = self.embedding(x)
         x = self.decoder(x)
-        # x = self.fc1(x)
-        output["reconstruction"] = x
-        return output
+        return ModelOutput(reconstruction=x)
 
 
 class ResNet18VAEEncoder(BaseEncoder):
@@ -82,75 +81,23 @@ class ResNet18VAEEncoder(BaseEncoder):
 
 
 class ResNet18VAEDecoder(BaseDecoder):
+    enc_out_dim = 512
+
     def __init__(
         self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs
     ):
         super(ResNet18VAEDecoder, self).__init__()
         latent_dim = model_config.latent_dim
         input_height = model_config.input_dim[-2]
-        self.decoder = resnet18_decoder(latent_dim, input_height, first_conv, maxpool1)
+        self.decoder = resnet18_decoder(
+            self.enc_out_dim, input_height, first_conv, maxpool1
+        )
+        self.embedding = nn.Linear(latent_dim, self.enc_out_dim)
 
     def forward(self, x):
+        x = self.embedding(x)
         x = self.decoder(x)
-        # x = self.fc1(x)
         return ModelOutput(reconstruction=x)
-
-
-# class ResNetVAEEncoder(BaseEncoder):
-#     def __init__(self, model_config: VAEConfig, encoder_fn, enc_out_dim, first_conv=False, maxpool1=False, **kwargs):
-#         super(ResNetVAEEncoder, self).__init__()
-
-#         input_height = model_config.input_dim[-2]
-#         latent_dim = model_config.latent_dim
-
-#         self.encoder = encoder_fn(first_conv, maxpool1)
-#         self.embedding = nn.Linear(enc_out_dim, latent_dim)
-#         self.log_var = nn.Linear(enc_out_dim, latent_dim)
-
-#     def forward(self, x):
-#         output = ModelOutput()
-#         x = self.encoder(x)
-#         output["embedding"] = self.embedding(x)
-#         output["log_covariance"] = self.log_var(x)
-#         return output
-
-
-# class ResNetVAEDecoder(BaseDecoder):
-#     def __init__(self, model_config: VAEConfig, decoder_fn, first_conv=False, maxpool1=False, **kwargs):
-#         super(ResNetVAEDecoder, self).__init__()
-
-#         latent_dim = model_config.latent_dim
-#         input_height = model_config.input_dim[-2]
-#         self.decoder = decoder_fn(latent_dim, input_height, first_conv, maxpool1)
-
-#     def forward(self, x):
-#         output = ModelOutput()
-#         x = self.decoder(x)
-#         output["reconstruction"] = x
-#         return output
-
-
-# class ResNet50VAEEncoder(ResNetVAEEncoder):
-#     def __init__(self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs):
-#         super().__init__(model_config, resnet50_encoder, enc_out_dim=2048, first_conv=first_conv, maxpool1=maxpool1, **kwargs)
-
-
-# class ResNet50VAEDecoder(ResNetVAEDecoder):
-#     def __init__(self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs):
-#         super().__init__(model_config, resnet50_decoder, first_conv=first_conv, maxpool1=maxpool1, **kwargs)
-
-
-# class ResNet18VAEEncoder(ResNetVAEEncoder):
-#     def __init__(self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs):
-#         super().__init__(model_config, resnet18_encoder, enc_out_dim=512, first_conv=first_conv, maxpool1=maxpool1, **kwargs)
-
-
-# class ResNet18VAEDecoder(ResNetVAEDecoder):
-#     def __init__(self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs):
-#         super().__init__(model_config, resnet18_decoder, first_conv=first_conv, maxpool1=maxpool1, **kwargs)
-
-from pythae import models
-from pythae.models import VQVAEConfig, VAEConfig
 
 
 class VAEPythaeWrapper(models.VAE):

--- a/bioimage_embed/models/bolts/vae.py
+++ b/bioimage_embed/models/bolts/vae.py
@@ -14,8 +14,11 @@ from pl_bolts.models.autoencoders import (
     resnet50_decoder,
     resnet50_encoder,
 )
+
+
 def count_params(model):
     return sum(p.numel() for p in model.parameters() if p.requires_grad)
+
 
 class ResNet50VAEEncoder(BaseEncoder):
     enc_out_dim = 2048
@@ -42,6 +45,7 @@ class ResNet50VAEEncoder(BaseEncoder):
 
 class ResNet50VAEDecoder(BaseDecoder):
     enc_out_dim = 512
+
     def __init__(
         self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs
     ):
@@ -49,7 +53,9 @@ class ResNet50VAEDecoder(BaseDecoder):
         latent_dim = model_config.latent_dim
         input_height = model_config.input_dim[-2]
         self.embedding = nn.Linear(latent_dim, self.enc_out_dim)
-        self.decoder = resnet50_decoder(self.enc_out_dim, input_height, first_conv, maxpool1)
+        self.decoder = resnet50_decoder(
+            self.enc_out_dim, input_height, first_conv, maxpool1
+        )
 
     def forward(self, x):
         x = self.embedding(x)

--- a/bioimage_embed/models/bolts/vae.py
+++ b/bioimage_embed/models/bolts/vae.py
@@ -2,6 +2,9 @@ from torch import nn
 from pythae.models.base.base_utils import ModelOutput
 from pythae.models.nn import BaseDecoder, BaseEncoder
 
+
+from pythae import models
+from pythae.models import VQVAEConfig, VAEConfig
 from pl_bolts.models import autoencoders
 from pythae.models import VQVAE, VQVAEConfig, VAE, VAEConfig
 
@@ -34,9 +37,7 @@ class ResNet50VAEEncoder(BaseEncoder):
         output = ModelOutput()
         x = self.encoder(x)
         # x = self.fc1(x)
-        output["embedding"] = self.embedding(x)
-        output["log_covariance"] = self.log_var(x)
-        return output
+        return ModelOutput(embedding=self.embedding(x), log_covariance=self.log_var(x))
 
 
 class ResNet50VAEDecoder(BaseDecoder):

--- a/bioimage_embed/models/bolts/vqvae.py
+++ b/bioimage_embed/models/bolts/vqvae.py
@@ -102,7 +102,7 @@ class BaseResNetVQVAEDecoder(BaseDecoder):
 
 
 class ResNet50VQVAEDecoder(BaseResNetVQVAEDecoder):
-    enc_out_dim = 2048
+    enc_out_dim = 512
     def __init__(
         self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs
     ):

--- a/bioimage_embed/models/bolts/vqvae.py
+++ b/bioimage_embed/models/bolts/vqvae.py
@@ -11,9 +11,16 @@ from pl_bolts.models.autoencoders import (
     resnet50_encoder,
 )
 
+
 class BaseResNetVQVAEEncoder(BaseEncoder):
     def __init__(
-        self, model_config: VAEConfig, resnet_encoder, enc_out_dim, first_conv=False, maxpool1=False, **kwargs
+        self,
+        model_config: VAEConfig,
+        resnet_encoder,
+        enc_out_dim,
+        first_conv=False,
+        maxpool1=False,
+        **kwargs
     ):
         super(BaseResNetVQVAEEncoder, self).__init__()
 
@@ -22,17 +29,17 @@ class BaseResNetVQVAEEncoder(BaseEncoder):
         self.enc_out_dim = enc_out_dim
 
         self.encoder = resnet_encoder(first_conv, maxpool1)
-        self.embedding = nn.Linear(self.enc_out_dim, self.latent_dim)
-        self.log_var = nn.Linear(self.enc_out_dim, self.latent_dim)
+        # self.embedding = nn.Linear(self.enc_out_dim, self.latent_dim)
+        # self.log_var = nn.Linear(self.enc_out_dim, self.latent_dim)
         self.prequantized = nn.Conv2d(self.enc_out_dim, self.latent_dim, 1, 1)
 
     def forward(self, inputs):
         x = self.encoder(inputs)
-        log_covariance = self.log_var(x)
+        # log_covariance = self.log_var(x)
         x = x.view(-1, self.enc_out_dim, 1, 1)
         embedding = self.prequantized(x)
-        return ModelOutput(embedding=embedding, log_covariance=log_covariance)
-
+        return ModelOutput(embedding=embedding)
+        # return ModelOutput(embedding=embedding, log_covariance=log_covariance)
 
 class ResNet50VQVAEEncoder(BaseResNetVQVAEEncoder):
     enc_out_dim = 2048
@@ -41,7 +48,12 @@ class ResNet50VQVAEEncoder(BaseResNetVQVAEEncoder):
         self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs
     ):
         super(ResNet50VQVAEEncoder, self).__init__(
-            model_config, resnet50_encoder, self.enc_out_dim, first_conv, maxpool1, **kwargs
+            model_config,
+            resnet50_encoder,
+            self.enc_out_dim,
+            first_conv,
+            maxpool1,
+            **kwargs
         )
 
 
@@ -52,7 +64,12 @@ class ResNet18VQVAEEncoder(BaseResNetVQVAEEncoder):
         self, model_config: VAEConfig, first_conv=False, maxpool1=False, **kwargs
     ):
         super(ResNet18VQVAEEncoder, self).__init__(
-            model_config, resnet18_encoder, self.enc_out_dim, first_conv, maxpool1, **kwargs
+            model_config,
+            resnet18_encoder,
+            self.enc_out_dim,
+            first_conv,
+            maxpool1,
+            **kwargs
         )
 
 

--- a/bioimage_embed/models/nets/resnet.py
+++ b/bioimage_embed/models/nets/resnet.py
@@ -1,5 +1,6 @@
 from torch import nn
 from torch.nn import functional as F
+import types
 
 
 class Residual(nn.Module):
@@ -149,3 +150,34 @@ class ResnetDecoder(nn.Module):
         x = F.relu(x)
 
         return self._conv_trans_2(x)
+
+
+def resnet18_encoder():
+    return ResnetEncoder(**resnet18_encoder_params)
+
+
+def resnet_encoder_50():
+    return ResnetEncoder(**resnet50_encoder_params)
+
+
+def resnet18_decoder(latent_dim):
+    return ResnetDecoder(**resnet18_encoder_params, out_channels=latent_dim)
+
+
+def resnet50_decoder(latent_dim):
+    return ResnetDecoder(**resnet50_encoder_params, out_channels=latent_dim)
+
+
+# Define a Namespace for ResNet18 Encoder
+resnet18_encoder_params = types.SimpleNamespace(
+    num_hiddens=64,
+    num_residual_layers=2,
+    num_residual_hiddens=64,
+)
+
+# Define a Namespace for ResNet50 Encoder
+resnet50_encoder_params = types.SimpleNamespace(
+    num_hiddens=256,
+    num_residual_layers=4,
+    num_residual_hiddens=256,
+)

--- a/bioimage_embed/shapes/transforms.py
+++ b/bioimage_embed/shapes/transforms.py
@@ -150,23 +150,21 @@ class CoordsToDistogram(torch.nn.Module):
         self.matrix_normalised = matrix_normalised
 
     def forward(self, coords):
-        # return self.get_distogram(img, self.size)
-        return self.get_distogram(coords, matrix_normalised=self.matrix_normalised)
+        return self.get_distogram(coords,
+                                matrix_normalised=self.matrix_normalised)
 
     def __repr__(self):
         return self.__class__.__name__ + f"(size={self.size})"
 
     def get_distogram(self, coords, matrix_normalised=False):
+
         xii, yii = coords
-        # distograms.append(euclidean_distances(np.array([xii,yii]).T))
-        distance_matrix = euclidean_distances(np.array([xii, yii]).T) / self.size**0.5
-        norm = np.linalg.norm(distance_matrix, "fro")
+        distance_matrix = euclidean_distances(np.array([xii, yii]).T)
         # Fro norm is the same as the L2 norm, but for positive semi-definite matrices
-        # norm = np.linalg.norm(distance_matrix)
-        # norm_distance_matrix = distance_matrix / self.size**0.5
         if matrix_normalised:
-            return distance_matrix / norm
-        return distance_matrix
+            return distance_matrix / np.linalg.norm(distance_matrix, "fro")
+        if not matrix_normalised:
+            return distance_matrix / np.linalg.norm([self.size, self.size])
 
 
 class ImageToCoords(torch.nn.Module):

--- a/scripts/shapes/shape_embed.py
+++ b/scripts/shapes/shape_embed.py
@@ -121,7 +121,7 @@ def shape_embed_process():
         # "num_embeddings": 16,
         "commitment_cost": 0.25,
         "decay": 0.99,
-        "loss_weights": [1, 1, 1, 1],
+        "frobenius_norm": False,
     }
 
     optimizer_params = {


### PR DESCRIPTION
Before the bolt-related decoders were using the size of the latent space rather than the native size of the output of resnet50's features. This meant that the decoder was trying to build a model different to the encoder. I think this fixes it. Fixed for vq and vae 