### PR TITLE
N colour channel autoencoding

### DIFF
--- a/bioimage_embed/lightning/__init__.py
+++ b/bioimage_embed/lightning/__init__.py
@@ -1,3 +1,4 @@
 from .pyro import LitAutoEncoderPyro
-from .torch import LitAutoEncoderTorch
+from .torch import LitAutoEncoderTorch,RGBLitAutoEncoderTorch, GrayscaleLitAutoEncoderTorch,ChannelAwareLitAutoEncoderTorch
+
 from .dataloader import DataModuleGlob,DataModule

--- a/bioimage_embed/lightning/tests/test_channel_aware.py
+++ b/bioimage_embed/lightning/tests/test_channel_aware.py
@@ -1,0 +1,35 @@
+import pytest
+import torch
+
+from .. torch import generalised_js_loss_z_loss, generalised_euclidean_distance_z_loss
+# Fixture for batch sizes
+@pytest.fixture(params=[1, 16])
+def batch_size(request):
+    return request.param
+
+# Fixture for channel sizes
+@pytest.fixture(params=[1, 3, 5])
+def channel_size(request):
+    return request.param
+
+# Fixture for z dimensions
+@pytest.fixture(params=[2**i for i in range(2, 9)])
+def z_dim(request):
+    return request.param
+
+# Fixture for generating tensors
+@pytest.fixture
+def input_tensor(batch_size, channel_size, z_dim):
+    return torch.randn(batch_size, channel_size, z_dim)
+
+# Test for generalised_js_loss_z_loss
+def test_generalised_js_loss_z_loss(input_tensor):
+    # Call the function and make assertions
+    loss = generalised_js_loss_z_loss(input_tensor)
+    assert loss is not None  # Example assertion
+
+# Test for generalised_euclidean_distance_z_loss
+def test_generalised_euclidean_distance_z_loss(input_tensor):
+    # Call the function and make assertions
+    loss = generalised_euclidean_distance_z_loss(input_tensor)
+    assert loss is not None  # Example assertion

--- a/bioimage_embed/lightning/tests/test_channel_aware.py
+++ b/bioimage_embed/lightning/tests/test_channel_aware.py
@@ -1,35 +1,45 @@
 import pytest
 import torch
 
-from .. torch import generalised_js_loss_z_loss, generalised_euclidean_distance_z_loss
+from ..torch import _channel_aware_losses
 # Fixture for batch sizes
 @pytest.fixture(params=[1, 16])
 def batch_size(request):
     return request.param
+
 
 # Fixture for channel sizes
 @pytest.fixture(params=[1, 3, 5])
 def channel_size(request):
     return request.param
 
+
 # Fixture for z dimensions
 @pytest.fixture(params=[2**i for i in range(2, 9)])
 def z_dim(request):
     return request.param
+
 
 # Fixture for generating tensors
 @pytest.fixture
 def input_tensor(batch_size, channel_size, z_dim):
     return torch.randn(batch_size, channel_size, z_dim)
 
-# Test for generalised_js_loss_z_loss
-def test_generalised_js_loss_z_loss(input_tensor):
-    # Call the function and make assertions
-    loss = generalised_js_loss_z_loss(input_tensor)
-    assert loss is not None  # Example assertion
 
-# Test for generalised_euclidean_distance_z_loss
-def test_generalised_euclidean_distance_z_loss(input_tensor):
+# Fixture for z dimensions
+@pytest.fixture(params=_channel_aware_losses)
+def loss_fn(request):
+    return request.param
+
+
+# Test for channel aware losses
+def test_z_loss(input_tensor, loss_fn):
     # Call the function and make assertions
-    loss = generalised_euclidean_distance_z_loss(input_tensor)
+    loss = loss_fn(input_tensor)
     assert loss is not None  # Example assertion
+    assert loss is not None
+    assert loss is not torch.nan
+    assert loss is not torch.inf
+    assert loss is not -torch.inf
+    assert loss.min() >= 0
+    assert len(loss.shape) == 0

--- a/bioimage_embed/lightning/torch.py
+++ b/bioimage_embed/lightning/torch.py
@@ -62,9 +62,8 @@ class LitAutoEncoderTorch(pl.LightningModule):
         return self.model.forward(x)
         # return self.model.forward(batch)
 
-    def batch_to_tensor(self, batch):
-        x,y = batch
-        return ModelOutput(data=x.float(), target=y)
+    def batch_to_tensor(self, batch: torch.Tensor) -> ModelOutput:
+        return ModelOutput(data=batch)
 
     def embedding_from_output(self, model_output):
         return model_output.z.view(model_output.z.shape[0], -1)
@@ -212,7 +211,7 @@ class GrayscaleLitAutoEncoderTorch(LitAutoEncoderTorch):
     def __init__(self, model, args=SimpleNamespace()):
         super().__init__(model, args)
 
-    def batch_to_tensor(self, batch):
+    def batch_to_tensor(self, batch: torch.Tensor) -> ModelOutput:
         return ModelOutput(data=batch.repeat(*self.repeat))
 
 
@@ -227,23 +226,26 @@ class ChannelAwareLitAutoEncoderTorch(GrayscaleLitAutoEncoderTorch):
     def expand_channels(self, tensor):
         b, c, *dims = tensor.shape
         tensor = tensor.unsqueeze(1)
-        tensor = tensor.permute(1, 2)
+        tensor = tensor.transpose(1, 2)
         tensor = tensor.reshape(b * c, 1, *dims)
         return tensor
 
     def contract_channels(self, tensor):
         b, c, dims = tensor.shape
         tensor = tensor.reshape(b // c, c, *dims)
-        tensor = tensor.permute(1, 2)
+        tensor = tensor.transpose(1, 2)
         tensor = tensor.squeeze(1)
         return tensor
 
-    def batch_to_tensor(self, batch):
-        x = self.expand_channels(batch["data"])
+    def batch_to_tensor(self, batch: torch.Tensor) -> ModelOutput:
+        x = self.expand_channels(batch)
         # This should be the grayscale repeat
-        return super().batch_to_tensor(x).data
+        return super().batch_to_tensor(x)
 
     def _(self, x: torch.Tensor):
+        # TODO forgotten what this should be named
+        
+        
         # Mean so that RGB model is gray again,
         # Will be noisy in early epochs but should be fine
         x = x.mean(dim=1, keepdim=True)
@@ -345,8 +347,15 @@ _model_classes = [
 ]
 
 
-_rgb_model_classes = [
+_3c_model_classes = [
+    LitAutoEncoderTorch,
     RGBLitAutoEncoderTorch,
+    ChannelAwareLitAutoEncoderTorch,
+]
+
+_1C_model_classes = [
+    GrayscaleLitAutoEncoderTorch,
+    ChannelAwareLitAutoEncoderTorch,
 ]
 
 def autoencoder_factory(model,args=SimpleNamespace()):

--- a/bioimage_embed/lightning/torch.py
+++ b/bioimage_embed/lightning/torch.py
@@ -367,21 +367,3 @@ def autoencoder_factory(model,args=SimpleNamespace()):
         return RGBLitAutoEncoderTorch(model, args)
     return LitAutoEncoderTorch(model, args)
 
-
-# class LitAutoEncoder(torch.nn.Module):
-#     def __init__(self, model, args=SimpleNamespace()):
-#         args.input_dim = args.input_dim
-#         if args.channel_aware == True:
-#            super(ChannelAwareLitAutoEncoderTorch, self).__init__(model, args) 
-#         if args.input_dim[0] == 1 & args.channel_aware == False:
-#             self.model = GrayscaleLitAutoEncoderTorch(model, args)
-#         if args.input_dim[0] == 3 & args.channel_aware == False:
-#             self.model = RGBLitAutoEncoderTorch(model, args)
-            
-            
-#         if args.input_dim[0] == 3:
-#             self.model = RGBLitAutoEncoderTorch(model, args)
-#         if args.input_dim[0] == 5:
-#             super(ChannelAwareLitAutoEncoderTorch, self).__init__(model, args)
-        
-    

--- a/bioimage_embed/shapes/lightning.py
+++ b/bioimage_embed/shapes/lightning.py
@@ -14,8 +14,7 @@ from types import SimpleNamespace
 
 def frobenius_norm_2D_torch(tensor: torch.Tensor) -> torch.Tensor:
     return torch.norm(tensor, p="fro", dim=(-2, -1), keepdim=True)
-
-
+ 
 class MaskEmbed(LitAutoEncoderTorch):
     def __init__(self, model, args=SimpleNamespace()):
         super().__init__(model, args)

--- a/bioimage_embed/tests/test_cli.py
+++ b/bioimage_embed/tests/test_cli.py
@@ -1,91 +1,42 @@
-import os
-import pytest
-from hydra import initialize, compose
-from .. import cli
-from pathlib import Path
-import os
-import pytest
-from ..cli import app
-from typer.testing import CliRunner
-from ..config import Config
-from .. import config
+# import os
+# import pytest
+# from ..hydra import main
 
-runner = CliRunner()
+# def test_main_creates_config():
+#     # Arrange
+#     config_path = "test_conf"
+#     job_name = "test_app"
 
-@pytest.fixture
-def config_dir():
-    return "test_conf"
+#     # Ensure the configuration directory does not exist initially
+#     if os.path.exists(config_path):
+#         os.rmdir(config_path)
 
+#     # Act
+#     main(config_path=config_path, job_name=job_name)
 
-@pytest.fixture
-def config_file():
-    return "config.yaml"
+#     # Assert
+#     assert os.path.exists(config_path), "Config directory was not created"
+#     assert os.path.isfile(os.path.join(config_path, "config.yaml")), "Config file was not created"
 
+#     # Clean up
+#     os.remove(os.path.join(config_path, "config.yaml"))
+#     os.rmdir(config_path)
 
-@pytest.fixture
-def config_path(config_dir, config_file):
-    return Path(config_dir).joinpath(config_file)
+# @pytest.mark.parametrize("config_path, job_name", [
+#     ("conf", "test_app"),
+#     ("another_conf", "another_job")
+# ])
+# def test_hydra_initializes(config_path, job_name):
+#     # Act
+#     main(config_path=config_path, job_name=job_name)
 
+#     # Assert
+#     # Here you can assert specifics about the cfg object if needed.
+#     # Since main does not return anything, you might need to adjust
+#     # the main function to return the cfg for more thorough testing.
 
-@pytest.fixture
-def config_directory_setup(config_dir, config_file, config_path):
-    if config_path.is_file():
-        config_path.unlink()
-
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-
-    yield config_dir, config_file, config_path
-
-    if config_path.is_file():
-        config_path.unlink()
-    if config_dir.is_dir():
-        config_dir.rmdir()
-
-
-def test_write_default_config_file(
-    config_path, config_dir, config_file, config_directory_setup
-):
-    # config_path, config_file = config_directory_setup
-    cli.write_default_config_file(config_path)
-    assert config_path.is_file(), "Default config file was not created"
-
-
-
-
-@pytest.fixture
-def cfg():
-    mock_dataset = config.ImageFolderDataset(
-        _target_="bioimage_embed.datasets.FakeImageFolder",
-    )
-    cfg = cli.get_default_config()
-    cfg.dataset = mock_dataset
-    return cfg
-
-
-def test_get_default_config(cfg):
-    assert cfg is not None, "Default config should not be None"
-    # Further assertions can be added to check specific config properties
-
-
-# def test_main_with_default_config(
-#     cfg, config_path, config_dir, config_file, config_directory_setup
-# ):
-#     test_get_default_config
-
-#     # cli.main(config_dir=config_dir, config_file=config_file, job_name="test_app")
-
-
-# @pytest.mark.skip("Computationally heavy")
-# def test_hydra():
-#     #  bie_train model.model="resnet50_vqvae" dataset._target_="bioimage_embed.datasets.FakeImageFolder"
-#     input_dim = [3, 224, 224]
-#     cfg = Config()
-#     cfg.dataloader.dataset._target_ = "bioimage_embed.datasets.FakeImageFolder"
-#     cfg.dataloader.dataset.image_size = input_dim
-#     cfg.recipe.model = "resnet18_vae"
-#     cfg.recipe.max_epochs = 1
-
-#     # cli.(cfg)
-
-
-#     result = runner.invoke(app, ["main", "+dataset.root=data", "--config_dir", "tests/sample_conf", "--config_file", "sample_config.yaml"])
+#     # Clean up
+#     if os.path.exists(config_path):
+#         os.remove(os.path.join(config_path, "config.yaml"))
+#         os.rmdir(config_path)
+        

--- a/bioimage_embed/tests/test_lightning.py
+++ b/bioimage_embed/tests/test_lightning.py
@@ -1,11 +1,8 @@
 from bioimage_embed.models import create_model
 import pytest
 import torch
-
 import pytorch_lightning as pl
-
 from bioimage_embed.models import create_model, MODELS
-
 from bioimage_embed.models import MODELS
 from bioimage_embed.lightning import DataModule
 from bioimage_embed.lightning.torch import _3c_model_classes
@@ -124,15 +121,19 @@ def trainer():
         max_epochs=1,
     )
 
-
 @pytest.mark.skip(reason="Expensive to run")
 def test_trainer_fit(trainer, lit_model, dataloader):
-    trainer.fit(lit_model, dataloader)
+    return trainer.fit(lit_model, dataloader)
 
+@pytest.fixture()
+def tensor(dataset):
+    return dataset.unsqueeze(0)
+    
+def test_dataset(lit_model, dataset):
+    return lit_model(dataset)
 
 def test_dataset_trainer(trainer, lit_model, dataset):
-    trainer.test(lit_model, dataset.unsqueeze(0))
-
+    return trainer.test(lit_model, dataset)
 
 def test_dataloader_trainer(trainer, lit_model, dataloader):
-    trainer.test(lit_model, dataloader)
+    return trainer.test(lit_model, dataloader)

--- a/bioimage_embed/tests/test_lightning.py
+++ b/bioimage_embed/tests/test_lightning.py
@@ -3,32 +3,17 @@ import pytest
 import torch
 
 import pytorch_lightning as pl
-import pythae
 
-
-from bioimage_embed.models import MODELS
-
-from bioimage_embed.lightning import LitAutoEncoderTorch, RGBLitAutoEncoderTorch, GrayscaleLitAutoEncoderTorch, ChannelAwareLitAutoEncoderTorch
-    
-import numpy as np
 from bioimage_embed.models import create_model, MODELS
 
 from bioimage_embed.models import MODELS
-from bioimage_embed import LitAutoEncoderTorch
 from bioimage_embed.lightning import DataModule
-from bioimage_embed.lightning.torch import _model_classes
+from bioimage_embed.lightning.torch import _3c_model_classes
 
-# LitAutoEncoderTorch:3
-# RGBLitAutoEncoderTorch:3
-# GrayscaleLitAutoEncoderTorch:1
-# ChannelAwareLitAutoEncoderTorch:1,3,5
 
-model_channel_map = {
-    LitAutoEncoderTorch: [3],
-    RGBLitAutoEncoderTorch: [3],
-    GrayscaleLitAutoEncoderTorch: [1],
-    ChannelAwareLitAutoEncoderTorch: [1, 3, 5],
-}
+@pytest.fixture(params=_3c_model_classes)
+def model_class(request):
+    return request.param
 
 @pytest.fixture(params=MODELS)
 def model_name(request):
@@ -86,36 +71,15 @@ def input_dim(image_dim, channel_dim):
 def data(input_dim):
     return torch.rand(1, *input_dim)
 
-@pytest.fixture(params=_model_classes)
-def model_class(request):
-    return request.param
+
 
 @pytest.fixture()
-def lit_model(model,model_class):
+def lit_model(model, model_class):
     return model_class(model)
     return LitAutoEncoderTorch(model)
 
-# @pytest.fixture()
-# def lit_model(model):
-#     return LitAutoEncoderTorch(model)
-
-@pytest.fixture()
-def model_and_batch(model_name, batch_size):
-    # Define combinations to ignore
-    ignored_combinations = [
-        ('ModelA', 1),
-        ('ModelB', 2),
-        # Add more combinations as needed
-    ]
-
-    if (model_name, batch_size) in ignored_combinations:
-        pytest.skip(f"Ignoring combination of {model_name} and batch size {batch_size}")
-
-    return model_name, batch_size
-
 def test_export_onxx(data, lit_model):
     return lit_model.to_onnx("model.onnx", data)
-
 
 @pytest.fixture()
 def model_torchscript(lit_model):
@@ -152,6 +116,7 @@ def dataloader(dataset, batch_size):
         pin_memory=False,
     )
 
+
 @pytest.fixture()
 def trainer():
     return pl.Trainer(
@@ -159,12 +124,15 @@ def trainer():
         max_epochs=1,
     )
 
+
 @pytest.mark.skip(reason="Expensive to run")
 def test_trainer_fit(trainer, lit_model, dataloader):
     trainer.fit(lit_model, dataloader)
 
+
 def test_dataset_trainer(trainer, lit_model, dataset):
     trainer.test(lit_model, dataset.unsqueeze(0))
+
 
 def test_dataloader_trainer(trainer, lit_model, dataloader):
     trainer.test(lit_model, dataloader)


### PR DESCRIPTION
### What:

Autoencoding images with any number of colour channels using models that only accept images with 3 colour channels

### Why

General method for using any backbone is valuable because it means we can use pretrained weights and avoid modifying models

### How

Current implement only works with 1 colour channel
For resnet50 you need 3, so we repeat the 1 channel along the C dim to make the tensors correct for the resnet
3 colour channels in generally the common input for backbones, so it's worth while trying to fit 1C into 3C

For any number of colour channels thats a bit harder,

In the case of 5 colour channels the trick here is to put the additional colour channels in the batch dimension which can generally be flexible in pytorch

i.e.

tensor in is ->` (b,c,y,x)`
you reshape it to ->` (b*c,1,y,x)`
you repeat along c as above -> `(b*c,3,y,x)`

This tensor will go through resnet50 then, all good

The trick then is to add a loss term on so encourage colours from the same image to be have the same latent represenation
To do this i've implemented euclidean distance and kl divergence losses

The trick being that you need to access your latent representation -> `(b*c,z),`
add the colour dim back by unsqueezing -> `(b*c,1,z)`
reshape -> `(b,c,z)`

and then do whatever operation you like to reduce the error along c

For instance one implementation here is making a distance matrix

so you take your reshape tensor ->` (b,c,z) `
add a dim ->` (b,1,c,z)`
tranpose dim 1 and 2 ->` (b,c,1,z)`
and feed those into pytorch cdist i.e. -> `cdist((b,1,c,z),(b,c,1,z))` -> `(c,c)` (you have to permute the dims a bit to get cdist to work)

KL div is also useful for the varational models but I've not played around with that as much

