### PR TITLE
Test cleaning and shortening

### DIFF
--- a/bioimage_embed/tests/conftest.py
+++ b/bioimage_embed/tests/conftest.py
@@ -1,0 +1,83 @@
+# from bioimage_embed import config
+from torchvision.datasets import FakeData
+import pytest
+from torchvision import transforms
+
+# from bioimage_embed.bie import BioImageEmbed
+from .. import config
+from ..bie import BioImageEmbed
+
+from hydra import initialize, compose
+
+
+@pytest.fixture
+def input_dim():
+    return [3, 224, 224]
+
+
+@pytest.fixture
+def dataset(input_dim):
+    transform = transforms.ToTensor()
+    return FakeData(size=64, image_size=input_dim, num_classes=2, transform=transform)
+
+
+# @pytest.fixture
+# def dataloader_cfg(dataset):
+#     return config.DataLoader(dataset=dataset, num_workers=0)
+
+
+@pytest.fixture
+def lite_model():
+    return "dummy_model"
+
+
+# @pytest.fixture
+# def cfg_model(model,input_dim):
+# return config.Model(model=model,input_dim=input_dim)
+
+# @pytest.fixture
+# def cfg(dataloader_cfg,model_cfg):
+#     return config.Config(dataloader=dataloader_cfg, model=model_cfg)
+
+
+@pytest.fixture
+def bie(cfg):
+    return BioImageEmbed(cfg)
+
+
+@pytest.fixture
+def hydra_cfg():
+    with initialize(config_path="."):
+        cfg = compose(config_name="config")
+        return cfg
+
+
+@pytest.fixture
+def cfg_recipe(lite_model):
+    return config.Recipe(model=lite_model)
+
+
+@pytest.fixture
+def cfg_trainer():
+    return config.Trainer(max_epochs=1, max_steps=1, fast_dev_run=True)
+
+
+@pytest.fixture
+def cfg_dataloader(dataset):
+    return config.DataLoader(dataset=dataset, num_workers=0)
+
+
+# TODO double check this is sensible
+@pytest.fixture
+def cfg(cfg_recipe, cfg_trainer, cfg_dataloader):
+    cfg = config.Config(
+        recipe=cfg_recipe, trainer=cfg_trainer, dataloader=cfg_dataloader
+    )
+    return cfg
+    # This is an alternative way to create a config object but it is less flexible and if the config object is changed in the future, this will break, i.e validation is not guaranteed
+
+    # cfg.dataloader.num_workers = 0  # This avoids processes being forked
+    # cfg.trainer.max_epochs = 1
+    # cfg.trainer.max_steps = 1
+    # cfg.trainer.fast_dev_run = True
+    # cfg.recipe.model = model

--- a/bioimage_embed/tests/test_cli.py
+++ b/bioimage_embed/tests/test_cli.py
@@ -2,7 +2,6 @@ import pytest
 from .. import cli
 from pathlib import Path
 from typer.testing import CliRunner
-from .. import config
 
 runner = CliRunner()
 
@@ -110,11 +109,9 @@ def test_init_hydra_with_invalid_config_file():
         cli.init_hydra(config_file="invalid_config.yaml")
 
 
-@pytest.mark.skip("redundant")
 def test_train(cfg):
     cli.train(cfg)
 
 
-@pytest.mark.skip("redundant")
 def test_check(cfg):
     cli.check(cfg)

--- a/bioimage_embed/tests/test_cli.py
+++ b/bioimage_embed/tests/test_cli.py
@@ -1,9 +1,7 @@
 import pytest
-from hydra import initialize, compose
 from .. import cli
 from pathlib import Path
 from typer.testing import CliRunner
-from .. import config
 
 runner = CliRunner()
 
@@ -111,53 +109,11 @@ def test_init_hydra_with_invalid_config_file():
         cli.init_hydra(config_file="invalid_config.yaml")
 
 
-@pytest.fixture
-def hydra_cfg():
-    with initialize(config_path="."):
-        cfg = compose(config_name="config")
-        return cfg
-
-
-@pytest.fixture
-def model():
-    return "dummy_model"
-
-
-@pytest.fixture
-def cfg_recipe(model):
-    return config.Recipe(model=model)
-
-
-@pytest.fixture
-def cfg_trainer():
-    return config.Trainer(max_epochs=1, max_steps=1, fast_dev_run=True)
-
-
-@pytest.fixture
-def cfg_dataloader():
-    return config.DataLoader(num_workers=0)
-
-
-# TODO double check this is sensible
-@pytest.fixture
-def cfg(cfg_recipe, cfg_trainer, cfg_dataloader):
-    cfg = config.Config(
-        recipe=cfg_recipe, trainer=cfg_trainer, dataloader=cfg_dataloader
-    )
-    return cfg
-    # This is an alternative way to create a config object but it is less flexible and if the config object is changed in the future, this will break, i.e validation is not guaranteed
-
-    # cfg.dataloader.num_workers = 0  # This avoids processes being forked
-    # cfg.trainer.max_epochs = 1
-    # cfg.trainer.max_steps = 1
-    # cfg.trainer.fast_dev_run = True
-    # cfg.recipe.model = model
-
-
-# @pytest.mark.skip("Computationally heavy")
+@pytest.mark.skip("redundant")
 def test_train(cfg):
     cli.train(cfg)
 
 
+@pytest.mark.skip("redundant")
 def test_check(cfg):
     cli.check(cfg)

--- a/bioimage_embed/tests/test_cli.py
+++ b/bioimage_embed/tests/test_cli.py
@@ -2,6 +2,7 @@ import pytest
 from .. import cli
 from pathlib import Path
 from typer.testing import CliRunner
+from .. import config
 
 runner = CliRunner()
 

--- a/bioimage_embed/tests/test_config.py
+++ b/bioimage_embed/tests/test_config.py
@@ -1,11 +1,7 @@
 from .. import config
-from .. import bie
-from ..bie import BioImageEmbed
 import pytest
 from hydra.utils import instantiate
-from torchvision.datasets import FakeData
-from torchvision import transforms
-from omegaconf import OmegaConf
+
 schema_map = config.__schemas__
 schemas = list(schema_map.values())
 
@@ -21,29 +17,6 @@ def test_instantiate(Schema):
     obj = instantiate(schema)
     assert obj is not None, "obj should not be None"
 
-@pytest.fixture
-def input_dim(): 
-    return [3, 224, 224]
-
-@pytest.fixture
-def dataset(input_dim):
-    transform = transforms.ToTensor()
-    return FakeData(size=64,
-                       image_size=input_dim,
-                       num_classes=1,
-                       transform=transform)
-@pytest.fixture
-def dataloader(dataset):
-    return config.DataLoader(dataset=dataset, num_workers=0)
-
-@pytest.fixture
-def model(input_dim):
-    return config.Model(input_dim=input_dim)
-
-@pytest.fixture
-def cfg(dataloader,model):
-    return config.Config(dataloader=dataloader, model=model)
-
 
 def test_config(cfg):
     assert cfg is not None, "Config should not be None"
@@ -52,12 +25,9 @@ def test_config(cfg):
 def test_config_instantiate(cfg):
     assert instantiate(cfg) is not None, "Config should not be None"
 
+
 def test_resolve(bie):
     assert bie.resolve()
-
-@pytest.fixture
-def bie(cfg):
-    return BioImageEmbed(cfg)
 
 
 def test_model_check(bie):


### PR DESCRIPTION
- Using conftest.py to group common fixtures, should save memory and time